### PR TITLE
ON-15433: Container image workflow, Containerfile preflight/linting, Makefile build/ var fix

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# (c) Copyright 2023 Advanced Micro Devices, Inc.
+name: "Container Image"
+
+on:
+  workflow_dispatch:
+    inputs:
+      registry-prefix:
+        description: Registry host and org
+        type: string
+      sfptpd-version:
+        description: sfptpd version
+        type: string
+      ubi-image:
+        description: UBI_IMAGE
+        type: string
+  push:
+    branches: [ master ]
+    tags: [ v*, sfptpd-* ]
+
+permissions:
+  contents: read
+  packages: write
+jobs:
+  container-build:
+    name: Container Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      REGISTRY_PREFIX: ${{ inputs.registry-prefix || '' }}
+      UBI_IMAGE: ${{ inputs.ubi-image || 'registry.access.redhat.com/ubi9-minimal:9.2' }}
+      SFPTPD_VERSION: ${{ inputs.sfptpd-version || '' }}
+      IMAGE_TAG_SUFFIX: ${{ vars.RELEASE == '' && '-dev' || '' }}
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+
+    - name: Metadata - env
+      run: |
+        repo="${GITHUB_REPOSITORY@L}"
+        echo "REGISTRY_PREFIX=${REGISTRY_PREFIX:-ghcr.io/$repo}" | tee -a "$GITHUB_ENV"
+
+        versioning_output=$(./scripts/sfptpd_versioning derive)
+        echo "SFPTPD_VERSION=${SFPTPD_VERSION:-$versioning_output}" | tee -a "$GITHUB_ENV"
+
+    - name: Metadata - Docker tagging
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.REGISTRY_PREFIX }}/sfptpd
+        tags: |
+          type=semver,pattern={{version}},suffix=${{ env.IMAGE_TAG_SUFFIX }}
+          type=match,pattern=sfptpd-([\d\.]+),group=1,suffix=${{ env.IMAGE_TAG_SUFFIX }}
+          type=ref,event=pr,prefix=pr-
+          type=raw,value=${{ env.SFPTPD_VERSION }},suffix=${{ env.IMAGE_TAG_SUFFIX }}
+          type=ref,event=branch,suffix=${{ env.IMAGE_TAG_SUFFIX }}
+          type=sha,prefix=git-,format=short
+        labels: |
+          org.opencontainers.image.version=${{ env.SFPTPD_VERSION }}
+
+    - if: ${{ contains(env.REGISTRY_PREFIX, 'ghcr.io') }}
+      name: Login to registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Containerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        push: true
+        build-args: |
+          SFPTPD_VERSION=${{ env.SFPTPD_VERSION }}
+          UBI_IMAGE=${{ env.UBI_IMAGE }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,40 +1,54 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
+# hadolint global ignore=DL3006,DL3059,DL3041,SC1091
+ARG UBI_IMAGE=redhat/ubi9-minimal:latest
+ARG SFPTPD_VERSION
 
-ARG UBI9_VERSION=latest
-
-FROM registry.access.redhat.com/ubi9-minimal:${UBI9_VERSION} AS builder
+FROM $UBI_IMAGE AS builder
+ARG SFPTPD_VERSION
 WORKDIR /src
 
-# git used to derive version number when run from a git clone
-RUN microdnf -y install git tar bzip2 redhat-rpm-config make gcc
+# hadolint ignore=DL3040
+RUN microdnf install -y tar gzip bzip2 redhat-rpm-config make gcc
 
 # Obtain headers from source packages in lieu of libmnl-devel and libcap-devel
-RUN microdnf -y --enablerepo=ubi-9-baseos-source download --source libmnl libcap
+RUN microdnf -y --enablerepo=ubi-*-baseos-source download --source libmnl libcap
 RUN mkdir libcap libmnl
 RUN rpm -i libcap-*.src.rpm \
  && tar xzf ~/rpmbuild/SOURCES/libcap-*.tar.gz --strip-components=1 -C libcap \
  && make -C libcap/libcap install
+# hadolint ignore=DL3003,SC1083
 RUN rpm -i libmnl-*.src.rpm \
  && tar xjf ~/rpmbuild/SOURCES/libmnl-*.tar.bz2 --strip-components=1 -C libmnl \
  && { cd libmnl && ./configure --prefix=/usr && make install; }
 
 # Use build flags from redhat-rpm-config to select the same optimisations
 # and hardening chosen by base platform
-RUN echo \
-  export CFLAGS=\"$(rpm --eval %{__global_cflags})\" \
-  export LDFLAGS=\"$(rpm --eval %{__global_ldflags})\" \
+RUN echo "export \
+  CFLAGS=\"$(rpm --eval '%{__global_cflags}')\" \
+  LDFLAGS=\"$(rpm --eval '%{__global_ldflags}')\"" \
   > /build.env
 
 # Build sfptpd
-COPY . /src/sfptpd
 WORKDIR /src/sfptpd
-RUN make patch_version
-RUN . /build.env && DESTDIR=/staging INST_INITS= make install
+RUN --mount=target=. \
+  source /build.env \
+  && make install BUILD_DIR=/src/sfptpd-build DESTDIR=/staging INST_INITS= \
+  && cp LICENSE /staging
 
-FROM registry.access.redhat.com/ubi9-minimal:${UBI9_VERSION} AS runtime
-RUN microdnf install -y libmnl
+FROM $UBI_IMAGE AS runtime
+ARG SFPTPD_VERSION
+LABEL \
+  name="sfptpd" \
+  summary="sfptpd" \
+  description="Solarflare Enhanced PTP Daemon" \
+  maintainer="Advanced Micro Devices, Inc." \
+  vendor="Advanced Micro Devices, Inc." \
+  version="$SFPTPD_VERSION" \
+  release="$SFPTPD_VERSION"
+RUN microdnf install -y libmnl && microdnf clean all
 COPY --from=builder /staging /
+COPY --from=builder /staging/LICENSE /licenses/
 WORKDIR /var/lib/sfptpd
 
 # Override any 'daemon' setting in selected configuration.

--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,8 @@ install: sfptpd sfptpdctl
 	install -d $(INST_PKGLICENSEDIR)
 	install -d $(INST_DEFAULTSDIR)
 	install -d $(INST_MANDIR)/man8
-	install -m 755 -p -D build/sfptpd $(INST_SBINDIR)/sfptpd
-	install -m 755 -p -D build/sfptpdctl $(INST_SBINDIR)/sfptpdctl
+	install -m 755 -p -D $(BUILD_DIR)/sfptpd $(INST_SBINDIR)/sfptpd
+	install -m 755 -p -D $(BUILD_DIR)/sfptpdctl $(INST_SBINDIR)/sfptpdctl
 	[ -n "$(filter sfptpmon,$(INST_OMIT))" ] || install -m 755 -p -D scripts/sfptpmon $(INST_SBINDIR)/sfptpmon
 	install -m 644 -p -D scripts/sfptpd.env $(INST_DEFAULTSDIR)/sfptpd
 	[ -z "$(filter systemd,$(INST_INITS))" ] || install -m 644 -p -D scripts/systemd/sfptpd.service $(INST_UNITDIR)/sfptpd.service

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ rpmbuild -bs sfptpd.spec
 
 ### Building a container image
 ```
-docker build .
+make patch_version
+docker build -f Containerfile .
 ```
 
 ### Running a container image


### PR DESCRIPTION
Example:
* [Workflow run](https://github.com/pcolledg-amd/sfptpd/actions/runs/6864209818/job/18665470838)
* [Container image](https://github.com/pcolledg-amd/sfptpd/pkgs/container/sfptpd%2Fsfptpd)

Static:
* Containerfile passes `hadolint`
* Workflow passes `actionlint`
* Container image passes Redhat Preflight except for `RunAsNonRoot` check.

Image tags:
```bash
$ oras repo tags localhost:5000/sfptpd
3.8.0.1000-dev # without `make patch_version`
3.8.0.1000-20231114.git59baea3-dev # with, this PR
git-54b65e2
master-dev
```

Moved versioning out of Containerfile to utilise read-only mount, can revert this to `COPY .`. Makefile fix of accidental hardcoding also required for building away from working tree.
