### PR TITLE
i386: build on 32-bit archs without 64-bit time_t

### DIFF
--- a/src/include/sfptpd_logging.h
+++ b/src/include/sfptpd_logging.h
@@ -69,6 +69,9 @@ typedef enum sfptpd_component_id {
 #define SFPTPD_FMT_SFTIMESPEC             "%" PRIu64 ".%09" PRIu32 "%03" PRIu32
 #define SFPTPD_FMT_SSFTIMESPEC            "%s%" PRId64 ".%012" PRIu64
 #define SFPTPD_FMT_SFTIMESPEC_FIXED       "%22" PRIu64 ".%09" PRIu32 "%03" PRIu32
+#define SFPTPD_FMT_SSFTIMESPEC_NS         "%s%" PRId64 ".%09" PRIu32
+
+/** Macros defining arguments for compound time formats */
 #define SFPTPD_ARGS_TIMESPEC(ts) \
 	(ts).tv_sec, \
 	(ts).tv_nsec
@@ -82,13 +85,17 @@ typedef enum sfptpd_component_id {
 	(ts).sec, \
 	(ts).nsec, \
 	_SFPTPD_NSEC_FRAC_TO_DEC((ts))
-#define SFPTPD_ARGS_SSFTIMESPEC(ts) \
+#define SFPTPD_ARGS_SSFTIMESPEC_S(ts) \
 	((ts).sec == -1 && ((ts).nsec != 0) ? "-" : ""), \
-	((ts).sec >= 0 || (ts).nsec == 0 ? ((ts).sec) : (ts).sec + 1), \
+	((ts).sec >= 0 || (ts).nsec == 0 ? ((ts).sec) : (ts).sec + 1)
+#define SFPTPD_ARGS_SSFTIMESPEC_NS(ts) \
+	SFPTPD_ARGS_SSFTIMESPEC_S(ts), \
+	((ts).sec >= 0 || (ts).nsec == 0 ? (ts).nsec : 1000000000 - (ts).nsec)
+#define SFPTPD_ARGS_SSFTIMESPEC(ts) \
+	SFPTPD_ARGS_SSFTIMESPEC_S(ts), \
 	((ts).sec >= 0 || (ts).nsec == 0 ? \
 		1000 * ((uint64_t)((ts).nsec)) + _SFPTPD_NSEC_FRAC_TO_DEC((ts)) : \
 		1000000000000 - 1000 * ((uint64_t)((ts).nsec)) - _SFPTPD_NSEC_FRAC_TO_DEC((ts)))
-
 
 /** Forward structure declarations */
 struct sfptpd_config;

--- a/src/include/sfptpd_misc.h
+++ b/src/include/sfptpd_misc.h
@@ -10,6 +10,8 @@
 #include <pthread.h>
 #include <linux/taskstats.h>
 
+#include "sfptpd_time.h"
+
 #define SFPTPD_HT_MAX_TABLE_SIZE 	(0x100)
 #define SFPTPD_HT_MAX_TABLE_ENTRIES 	(0x10000)
 
@@ -141,7 +143,7 @@ bool sfptpd_is_program_running(const char *program_name);
  * @param format Format string as per strftime(3)
  * @param time_p The UTC time to format
  */
-void sfptpd_local_strftime(char *s, size_t max, const char *format, const time_t *timep);
+void sfptpd_local_strftime(char *s, size_t max, const char *format, const sfptpd_secs_t *timep);
 
 
 /** Create a hash table

--- a/src/include/sfptpd_time.h
+++ b/src/include/sfptpd_time.h
@@ -20,12 +20,12 @@ typedef long double sfptpd_time_t;
 #define ONE_BILLION (1.0e9)
 #define ONE_MILLION (1.0e6)
 
-
 typedef int64_t sfptpd_time_fp16_t;
+typedef int64_t sfptpd_secs_t;
 
 /* sfptpd high precision time struct */
 struct sfptpd_timespec {
-	int64_t sec;
+	sfptpd_secs_t sec;
 	uint32_t nsec;
 	uint32_t nsec_frac;
 };

--- a/src/ptp/ptpd2/dep/msg.c
+++ b/src/ptp/ptpd2/dep/msg.c
@@ -3029,9 +3029,11 @@ void msgDump(PtpInterface *ptpInterface)
 {
 	char temp[MAXTIMESTR], time[MAXTIMESTR + 8];
 	struct timeval now;
+	sfptpd_secs_t s;
 
 	gettimeofday(&now, 0);
-	sfptpd_local_strftime(temp, sizeof(temp), "%Y-%m-%d %X", &now.tv_sec);
+	s = (sfptpd_secs_t) now.tv_sec;
+	sfptpd_local_strftime(temp, sizeof(temp), "%Y-%m-%d %X", &s);
 	snprintf(time, sizeof(time), "%s.%06ld", temp, now.tv_usec);
 	time[sizeof(time) - 1] = '\0';
 

--- a/src/ptp/sfptpd_ptp_monitor.c
+++ b/src/ptp/sfptpd_ptp_monitor.c
@@ -789,7 +789,7 @@ static void monitor_write_json_rx_event(void *record, void *context)
 		"\"sync-seq\": %d, "
 		"\"offset-from-master\": %Lf, "
 		"\"mean-path-delay\": %Lf, "
-		"\"sync-ingress-timestamp\": %ld.%09d } }\n",
+		"\"sync-ingress-timestamp\": " SFPTPD_FMT_SSFTIMESPEC_NS " } }\n",
 		rx_event->common.monitor_seq_id,
 		monitor_time,
 		rx_event->common.monitor_timestamp.nsec / 1000,
@@ -798,7 +798,7 @@ static void monitor_write_json_rx_event(void *record, void *context)
 		rx_event->common.event_seq_id,
 		isnormal(offset) ? offset : 0.0L,
 		isnormal(mpd) ? mpd : 0.0L,
-		ts.sec, ts.nsec);
+		SFPTPD_ARGS_SSFTIMESPEC_NS(ts));
 }
 
 
@@ -824,7 +824,7 @@ static void monitor_write_json_tx_event(void *record, void *context)
 		"\"source-port\": \"" PORT_ID_FORMAT_VAR_WIDTH "\", "
 		"\"message-type\": \"%s\", "
 		"\"event-seq-id\": %d, "
-		"\"egress-timestamp\": %ld.%09d } }\n",
+		"\"egress-timestamp\": " SFPTPD_FMT_SSFTIMESPEC_NS " } }\n",
 		tx_event->common.monitor_seq_id,
 		monitor_time,
 		tx_event->common.monitor_timestamp.nsec / 1000,
@@ -832,7 +832,7 @@ static void monitor_write_json_tx_event(void *record, void *context)
 		PORT_ID_CONTENT(tx_event->common.ref_port_id),
 		mtype,
 		tx_event->common.event_seq_id,
-		ts.sec, ts.nsec);
+		SFPTPD_ARGS_SSFTIMESPEC_NS(ts));
 }
 
 

--- a/src/sfptpd_engine.c
+++ b/src/sfptpd_engine.c
@@ -1025,7 +1025,7 @@ static void write_rt_stats_json(FILE* json_stats_fp,
 	/* Add clock time */
 	if (entry->clock_master != NULL) {
 		if (entry->has_m_time) {
-			time_t secs = entry->time_master.sec;
+			sfptpd_secs_t secs = entry->time_master.sec;
 			sfptpd_local_strftime(ftime, (sizeof ftime) - 1, "%Y-%m-%d %H:%M:%S", &secs);
 			LPRINTF(json_stats_fp, ",\"time\":\"%s.%09" PRIu32 "\"",
 				ftime, entry->time_master.nsec);
@@ -1042,7 +1042,7 @@ static void write_rt_stats_json(FILE* json_stats_fp,
 	LPRINTF(json_stats_fp, "},\"clock-slave\":{\"name\":\"%s\"",
 		sfptpd_clock_get_long_name(entry->clock_slave));
 	if (entry->has_s_time) {
-		time_t secs = entry->time_slave.sec;
+		sfptpd_secs_t secs = entry->time_slave.sec;
 		sfptpd_local_strftime(ftime, (sizeof ftime) - 1, "%Y-%m-%d %H:%M:%S", &secs);
 		LPRINTF(json_stats_fp, ",\"time\":\"%s.%09" PRIu32 "\"",
 			ftime, entry->time_slave.nsec);
@@ -1238,7 +1238,7 @@ static void on_schedule_leap_second(struct sfptpd_engine *engine,
 		/* Go to the scheduled state */
 		engine->leap_second.state = LEAP_SECOND_STATE_SCHEDULED;
 		char ftime[8];
-		time_t leap_second_time = (time_t)sfptpd_time_timespec_to_float_s(&engine->leap_second.time);
+		sfptpd_secs_t leap_second_time = (sfptpd_secs_t)sfptpd_time_timespec_to_float_s(&engine->leap_second.time);
 		sfptpd_local_strftime(ftime, sizeof(ftime), "%H:%M", &leap_second_time);
 		NOTICE("leap second %s scheduled for UTC midnight (local time: %s)\n",
 		       (type == SFPTPD_LEAP_SECOND_61)? "61": "59", ftime);
@@ -1326,7 +1326,7 @@ static void on_test_leap_second(struct sfptpd_engine *engine,
 		update_leap_second_status(engine, type);
 
 		char ftime[8];
-		time_t leap_second_time = (time_t)sfptpd_time_timespec_to_float_s(&engine->leap_second.time);
+		sfptpd_secs_t leap_second_time = (sfptpd_secs_t)sfptpd_time_timespec_to_float_s(&engine->leap_second.time);
 		sfptpd_local_strftime(ftime, sizeof(ftime), "%H:%M", &leap_second_time);
 		INFO("leap second %s test at UTC midnight (local time: %s)\n",
 		     (type == SFPTPD_LEAP_SECOND_61)? "61": "59", ftime);

--- a/src/sfptpd_logging.c
+++ b/src/sfptpd_logging.c
@@ -1068,12 +1068,14 @@ void sfptpd_log_get_time(struct sfptpd_log_time *time)
 {
 	struct timeval now;
 	char temp[SFPTPD_LOG_TIME_STR_MAX];
+	sfptpd_secs_t s;
 	int rc;
 	
 	assert(time != NULL);
 	
 	gettimeofday(&now, 0);
-	sfptpd_local_strftime(temp, sizeof(temp), "%Y-%m-%d %X", &now.tv_sec);
+	s = (sfptpd_secs_t) now.tv_sec;
+	sfptpd_local_strftime(temp, sizeof(temp), "%Y-%m-%d %X", &s);
 
 	rc = snprintf(time->time, sizeof(time->time), "%s.%06ld", temp, now.tv_usec);
 	assert(rc < sizeof(time->time));

--- a/src/sfptpd_misc.c
+++ b/src/sfptpd_misc.c
@@ -177,10 +177,11 @@ int sfptpd_find_running_programs(struct sfptpd_prog *others)
 }
 
 
-void sfptpd_local_strftime(char *s, size_t max, const char *format, const time_t *timep)
+void sfptpd_local_strftime(char *s, size_t max, const char *format, const sfptpd_secs_t *timep)
 {
 	struct tm tm;
-	struct tm *ltime = localtime_r(timep, &tm);
+	time_t tt = (time_t) *timep;
+	struct tm *ltime = localtime_r(&tt, &tm);
 
 	if (ltime != NULL) {
 		strftime(s, max, format, ltime);

--- a/test/sfptpd_test_time.c
+++ b/test/sfptpd_test_time.c
@@ -524,7 +524,7 @@ static void print_stack(const struct test_val *stack, int sp)
 		const struct test_val *sv = &stack[i];
 		switch(stack[i].type) {
 		case TYPE_I:
-			printf(" %ld", sv->i);
+			printf(" %" PRId64, sv->i);
 			break;
 		case TYPE_F:
 			printf(" " SFPTPD_FORMAT_FLOAT "L", sv->f);
@@ -568,7 +568,7 @@ static bool check_var(uint64_t key) {
 		if (isprint(key) && !isspace(key))
 			printf("invalid variable '%c'\n", (char) key);
 		else
-			printf("invalid variable 0x%lx\n", key);
+			printf("invalid variable 0x%" PRIx64 "\n", key);
 		return true;
 	}
 	return false;
@@ -1061,7 +1061,7 @@ static enum result run_test(const struct test_details *test, mem_t *mem,
 				printf("   B(%s)\n", s1->b ? "true" : "false");
 				break;
 			case TYPE_I:
-				printf("   I(%ld)\n", s1->i);
+				printf("   I(%" PRId64 ")\n", s1->i);
 				break;
 			case TYPE_F:
 				printf("   F(" SFPTPD_FORMAT_FLOAT ")\n", s1->f);
@@ -1077,7 +1077,7 @@ static enum result run_test(const struct test_details *test, mem_t *mem,
 		case OP_PRINTX:
 			switch (s1->type) {
 			case TYPE_I:
-				printf("   I(%lx)\n", s1->i);
+				printf("   I(%" PRIx64 ")\n", s1->i);
 				break;
 			case TYPE_T:
 				printf("   T(%016" PRIX64 ".%08X%08X\n",


### PR DESCRIPTION
Fixes #7 by defining an application-specific type `sfptpd_secs_t` which is `int64_t`. Some explicit format specifiers are also required.

Alternative approaches of using `__time64_t` or `__TIME64_T_TYPE` are not very compatible with old OSs; this approach is simpler than working with these.

### Tested with 32-bit userspace, kernel and CPU

```
Linux cook 6.5.0-3-686 #1 SMP PREEMPT_DYNAMIC Debian 6.5.8-1 (2023-10-22) i686 GNU/Linux
```

```
UNIT TEST RESULTS SUMMARY
seed: 1715450424
```

|    | Unit test   | Run     | Result                    |
| -- | ----------- | ------- | ------------------------- |
|  0 | config      | Run     | Pass                      |
|  1 | hash        | Run     | Pass                      |
|  2 | stats       | Run     | Pass                      |
|  3 | filters     | Not run |                           |
|  4 | threading   | Not run |                           |
|  5 | bic         | Run     | Pass                      |
|  6 | fmds        | Not run |                           |
|  7 | link        | Run     | Pass                      |
|  8 | time        | Run     | Pass                      |

```
2024-02-01 09:40:33.999310: info: Solarflare Enhanced PTP Daemon, version 3.8.0.1000
2024-02-01 09:40:35.246050: debug: sync engine created successfully
```
PTP has also been observed working.