### PR TITLE
y2038: support 64-bit time on recent 32-bit systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ CONDITIONAL_DEFS := \
  $(if $(value GLIBC_COMPAT),-DSFPTPD_GLIBC_COMPAT) \
  $(shell $(call if_header_then,sys/capability.h,-DHAVE_CAPS)) \
  $(shell $(call if_header_then,linux/ethtool_netlink.h,-DHAVE_ETHTOOL_NETLINK)) \
+ $(shell $(call if_header_then,linux/time_types.h,-DHAVE_TIME_TYPES)) \
  $(shell $(call if_defn_then,linux/if_link.h,IFLA_PERM_ADDRESS)) \
  $(shell $(call if_defn_then,linux/if_link.h,IFLA_PARENT_DEV_NAME))
 CONDITIONAL_LIBS := \

--- a/src/include/sfptpd_time.h
+++ b/src/include/sfptpd_time.h
@@ -4,7 +4,10 @@
 #ifndef _SFPTPD_TIME_H
 #define _SFPTPD_TIME_H
 
-#include <time.h>
+#ifdef HAVE_TIME_TYPES
+#include <linux/time_types.h>
+#endif
+#include <sys/time.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <math.h>
@@ -302,6 +305,19 @@ static inline void sfptpd_time_from_std_floor(struct sfptpd_timespec *sfts, cons
 	sfts->nsec = ts->tv_nsec;
 	sfts->nsec_frac = 0;
 }
+
+#ifdef HAVE_TIME_TYPES
+/** Convert a kernel timestamp to struct sfptpd_timespec.
+ * @param sfts  The structure to fill.
+ * @param ts The structure to copy.
+ */
+static inline void sfptpd_time_from_kernel_floor(struct sfptpd_timespec *sfts, const struct __kernel_timespec *ts)
+{
+	sfts->sec = ts->tv_sec;
+	sfts->nsec = ts->tv_nsec;
+	sfts->nsec_frac = 0;
+}
+#endif
 
 /** Initialise a struct sfptpd_timespec to zero.
  * @param ts  The structure to clear.

--- a/src/ptp/ptpd2/dep/msg.c
+++ b/src/ptp/ptpd2/dep/msg.c
@@ -3028,13 +3028,11 @@ appendSlaveStatusTLV(SlaveStatus *data, Octet *buf, size_t space)
 void msgDump(PtpInterface *ptpInterface)
 {
 	char temp[MAXTIMESTR], time[MAXTIMESTR + 8];
-	struct timeval now;
-	sfptpd_secs_t s;
+	struct sfptpd_timespec now;
 
-	gettimeofday(&now, 0);
-	s = (sfptpd_secs_t) now.tv_sec;
-	sfptpd_local_strftime(temp, sizeof(temp), "%Y-%m-%d %X", &s);
-	snprintf(time, sizeof(time), "%s.%06ld", temp, now.tv_usec);
+	sfclock_gettime(CLOCK_REALTIME, &now);
+	sfptpd_local_strftime(temp, sizeof(temp), "%Y-%m-%d %X", &now.sec);
+	snprintf(time, sizeof(time), "%s.%06" PRId32, temp, now.nsec / 1000);
 	time[sizeof(time) - 1] = '\0';
 
 	msgDebugHeader(&ptpInterface->msgTmpHeader, time);

--- a/src/sfptpd_logging.c
+++ b/src/sfptpd_logging.c
@@ -1066,18 +1066,17 @@ struct sfptpd_log *sfptpd_log_open_remote_monitor(void)
 
 void sfptpd_log_get_time(struct sfptpd_log_time *time)
 {
-	struct timeval now;
 	char temp[SFPTPD_LOG_TIME_STR_MAX];
-	sfptpd_secs_t s;
+	struct sfptpd_timespec now;
 	int rc;
 	
 	assert(time != NULL);
 	
-	gettimeofday(&now, 0);
-	s = (sfptpd_secs_t) now.tv_sec;
-	sfptpd_local_strftime(temp, sizeof(temp), "%Y-%m-%d %X", &s);
+	sfclock_gettime(CLOCK_REALTIME, &now);
+	sfptpd_local_strftime(temp, sizeof(temp), "%Y-%m-%d %X", &now.sec);
 
-	rc = snprintf(time->time, sizeof(time->time), "%s.%06ld", temp, now.tv_usec);
+	rc = snprintf(time->time, sizeof(time->time), "%s.%06" PRId32,
+		      temp, now.nsec / 1000);
 	assert(rc < sizeof(time->time));
 }
 

--- a/src/sfptpd_phc.c
+++ b/src/sfptpd_phc.c
@@ -33,18 +33,24 @@
 #include "sfptpd_priv.h"
 
 
+#ifdef SFPTPD_GLIBC_COMPAT
 /****************************************************************************
  * Missing kernel API bits and pieces
  ****************************************************************************/
 
 /* The oldest distribution we support has kernel support for PHC but the
  * syscall is missing in that glibc version. In this case we need to create our
- * own version of clock_adjtime() and invoke the syscall. */
+ * own version of clock_adjtime() and invoke the syscall.
+ *
+ * Avoid including this where not needed as it overrides glibc's smarts for
+ * handling 64-bit time on 32-bit architectures.
+ */
 #pragma weak clock_adjtime
 int clock_adjtime(clockid_t clock, struct timex *timex_block)
 {
 	return syscall(__NR_clock_adjtime, clock, timex_block);
 }
+#endif
 
 
 /****************************************************************************


### PR DESCRIPTION
With this solution, define `-D_TIME_BITS=64` to build sfptpd to use 64-bit time interfaces on 32-bit systems with supporting libc and kernel. Fixes #12.

This patch series has been tested on i386 but may be more relevant to armhf and armel architectures as these are getting updated for 64-bit time in Debian (https://wiki.debian.org/ReleaseGoals/64bit-time) which i386 is not.

32-bit userspace on 64-bit kernel support is also re-enabled as this can be supported correctly using PHC APIs.

> [!CAUTION]
> If trying this solution out on a 32-bit system with dates from 2106 beware that other system components which are not yet Y2038-ready may fail catastrophically when encountering such dates as libc functions will fail reporting an overflow - typically affecting `stat()` operations on system files. This can be rectified by moving affected timestamps back into the 32-bit range.