### PR TITLE
runit: add runit supervisor integration

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Source: sfptpd
 Section: net
 Priority: optional
 Maintainer: AMD NIC Support <support-nic@amd.com>
-Build-Depends: debhelper-compat (= 12), libmnl-dev, libcap-dev, dh-python, python3, dh-sysuser
+Build-Depends: debhelper-compat (= 12), libmnl-dev, libcap-dev, python3, dh-python, dh-sysuser, dh-runit
 Standards-Version: 4.6.0
 Homepage: https://github.com/Xilinx-CNS/sfptpd
 Rules-Requires-Root: no
@@ -16,7 +16,8 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Recommends: sfptpd-python3
 Suggests: ntpsec | ntp
-Conflicts: systemd-timesyncd, openntpd
+Conflicts: ${runit:Conflicts}, systemd-timesyncd, openntpd
+Breaks: ${runit:Breaks}
 Description: System time sync daemon supporting PTP, NTP and 1PPS
  Use multiple PTP an PPS sources and sync local clocks together in one
  integrated application with high quality timestamp filtering supporting

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 # Rely on dh_installchangelog to install the upstream changelog from source tree
 
 %:
-	prefix=/usr INST_INITS="systemd" INST_OMIT="c-examples changelog" dh $@ --with python3,sysuser
+	prefix=/usr INST_INITS="systemd" INST_OMIT="c-examples changelog" dh $@ --with python3,sysuser,runit
 
 override_dh_auto_test:
 	make fast_test

--- a/debian/sfptpd.runit
+++ b/debian/sfptpd.runit
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# (c) Copyright 2024 Advanced Micro Devices, Inc.
+
+scripts/runit/run name=sfptpd,logscript

--- a/scripts/runit/run
+++ b/scripts/runit/run
@@ -1,0 +1,8 @@
+#!/usr/bin/env /lib/runit/invoke-run
+# SPDX-License-Identifier: BSD-3-Clause
+# (c) Copyright 2023-2024 Advanced Micro Devices, Inc.
+
+set -e
+exec 2>&1
+echo "Starting ${PWD##*/}..."
+exec $TASKSET /usr/sbin/sfptpd --no-daemon $OPTIONS $SFPTPD_USER


### PR DESCRIPTION
Add first class support for the [runit](https://packages.debian.org/sid/runit) supervisor (which is a replacement for _sysvinit_ and _systemd_, etc.)

The system configuration is automatically picked up from `/etc/default/sfptpd` as it is with _sysvinit_ and _systemd_. Note that the _runit-helper_ dependency is likely already to be installed on most systems as at least _openssh-server_ also comes with _runit_ integration that will pull this in.

Tested with Debian 10 (oldoldstable), 12 (stable) and Devuan 4 (oldstable) and 6 (testing).

The `dh_runit` _debhelper_ in Ubuntu seems to be ineffective, nevertheless Ubuntu continues to build packages suitable for _systemd_ and _sysvinit_ (and by extension, _runit_, via init script fallback).

Metadata from build on Debian 10:
```
Pre-Depends: init-system-helpers (>= 1.54~)
Depends: libc6 (>= 2.27), libcap2 (>= 1:2.10), libmnl0 (>= 1.0.3-4~), runit-helper (>= 2.8.1~), sysuser-helper (<< 1.4)
Recommends: sfptpd-python3
Suggests: ntpsec | ntp
Conflicts: openntpd, runit (<< 2.1.2-20~), systemd-timesyncd
Breaks: runit (<< 2.1.2-20~)
```

Starting, stopping, reconfiguring, installing, uninstalling, upgrading, logging and CPU pinning seem to work seemlessly.