### PR TITLE
Add tstool and option to deduplicate phc devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     `gpsd ::1 2947` and set as time of day source.
 - Add Y2038 support when built for 32-bit targets with 64-bit time enabled.
   (Xilinx-CNS/sfptpd#12)
+- Add hardware clock control utility 'tstool'. This is a diagnostic tool
+  whose interface is not guaranteed to be stable.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Add `phc_dedup` option to identify duplicate PHC devices sharing a single
+  NIC clock and treat as one device. Only relevant to non-Solarflare adapters.
+  (SWPTP-1348)
+  - This option requires a calibration step that may take a few seconds.
 - Add `avoid_efx_ioctl` option to avoid sfc proprietary ioctl(). (SWPTP-1535)
   - This prevents setting of the sync flags optionally used by Onload.
 

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ $(BUILD_DIR)/%.service: scripts/systemd/%.service $(BUILD_DIR)
 	sed s,/etc/sysconfig,$(patsubst $(DESTDIR)%,%,$(INST_DEFAULTSDIR)),g < $< > $@
 
 .PHONY: install
-install: sfptpd sfptpdctl sfptpd_priv_helper $(addprefix $(BUILD_DIR)/,sfptpd.service)
+install: sfptpd sfptpdctl sfptpd_priv_helper tstool $(addprefix $(BUILD_DIR)/,sfptpd.service)
 	install -d $(INST_PKGDOCDIR)/config
 	install -d $(INST_PKGDOCDIR)/examples
 	install -d $(INST_PKGLICENSEDIR)
@@ -142,6 +142,7 @@ install: sfptpd sfptpdctl sfptpd_priv_helper $(addprefix $(BUILD_DIR)/,sfptpd.se
 	install -d $(INST_MANDIR)/man8
 	install -m 755 -p -D $(BUILD_DIR)/sfptpd $(INST_SBINDIR)/sfptpd
 	install -m 755 -p -D $(BUILD_DIR)/sfptpdctl $(INST_SBINDIR)/sfptpdctl
+	install -m 755 -p -D $(BUILD_DIR)/tstool $(INST_SBINDIR)/tstool
 	[ -n "$(filter sfptpmon,$(INST_OMIT))" ] || install -m 755 -p -D scripts/sfptpmon $(INST_SBINDIR)/sfptpmon
 	install -m 644 -p -D scripts/sfptpd.env $(INST_DEFAULTSDIR)/sfptpd
 	[ -z "$(filter systemd,$(INST_INITS))" ] || install -m 644 -p -D $(BUILD_DIR)/sfptpd.service $(INST_UNITDIR)/sfptpd.service
@@ -160,6 +161,7 @@ install: sfptpd sfptpdctl sfptpd_priv_helper $(addprefix $(BUILD_DIR)/,sfptpd.se
 	install -m 755 -p -t $(INST_PKGLIBEXECDIR) $(BUILD_DIR)/sfptpd_priv_helper
 	install -m 644 -p -t $(INST_MANDIR)/man8 $(wildcard doc/sfptpd.8)
 	install -m 644 -p -t $(INST_MANDIR)/man8 $(wildcard doc/sfptpdctl.8)
+	install -m 644 -p -t $(INST_MANDIR)/man8 $(wildcard doc/tstool.8)
 	[ -n "$(filter sfptpmon,$(INST_OMIT))" ] || install -m 644 -p -t $(INST_MANDIR)/man8 $(wildcard doc/sfptpmon.8)
 
 .PHONY: uninstall

--- a/README.md
+++ b/README.md
@@ -79,8 +79,19 @@ network ports on a single adapter. Some NICs, however, present separate and
 _apparently_ independent PHC devices for each network port which actually
 represent the same underlying physical clock.
 
-When using third party NICs affected by this issue the recommended mitigation
+#### Workaround 1: list clocks explicitly
+
+When using third party NICs affected by this issue, the recommended mitigation
 is to list explicitly the NIC clocks to be disciplined with `clock_list`.
+
+#### Workaround 2: clock deduplication
+
+An experimental option, `phc_dedup on` will identify duplicate PHC devices
+for a single underlying clock and retain only one which has effective control.
+This is achieved via a test that involes temporarily adjusting the relevant
+NIC clocks, so should not be done while those interfaces are in use by
+applications for timestamping (hardware timestamping will be disabled
+globally during this calibration period to enforce this).
 
 ## Footnotes
 

--- a/debian/sfptpd.install
+++ b/debian/sfptpd.install
@@ -3,6 +3,7 @@
 
 /usr/sbin/sfptpd
 /usr/sbin/sfptpdctl
+/usr/sbin/tstool
 /usr/libexec/sfptpd/sfptpd_priv_helper
 /lib/systemd/system/sfptpd.service
 /etc/sfptpd.conf

--- a/debian/sfptpd.manpages
+++ b/debian/sfptpd.manpages
@@ -3,3 +3,4 @@
 
 /usr/share/man/man8/sfptpd.8
 /usr/share/man/man8/sfptpdctl.8
+/usr/share/man/man8/tstool.8

--- a/doc/tstool.8
+++ b/doc/tstool.8
@@ -1,0 +1,52 @@
+.Dd July 13, 2024
+.Os Linux
+.Dt TSTOOL 8 SMM
+.Sh NAME
+.Nm tstool
+.Nd Timestamping control utility
+.Sh SYNOPSIS
+.Nm
+clock list
+.Nm
+clock info
+.Ar clock
+.Nm
+clock get
+.Ar clock
+.Nm
+clock step
+.Ar clock
+.Ar offset
+.Nm
+clock slew
+.Ar clock
+.Ar ppb
+.Nm
+clock set_to
+.Ar clock1
+.Ar clock2
+.Nm
+clock diff
+.Ar clock1
+.Ar clock2
+.Sh DESCRIPTION
+Examine and adjust PTP Hardware Clock devices and the system clock.
+.Pp
+This utility uses the mechanisms available to sfptpd to manipulate precision clocks on the system.
+.Pp
+Clocks may be specified by phc number, interface name or 'system'.
+.Sh BUGS
+Please raise bug reports at:
+.Aq https://github.com/Xilinx-CNS/sfptpd/issues
+.Pp
+Support for users of AMD Solarflare NICs is available from:
+.Aq support-nic@amd.com
+.Sh AUTHORS
+Advanced Micro Devices, Inc.
+.Sh SEE ALSO
+.Xr sfptpd 8 .
+.Pp
+Full documentation is available at:
+.Aq https://docs.amd.com/r/en-US/ug1602-ptp-user
+.Sh COPYRIGHT
+Copyright (c) 2024 Advanced Micro Devices, Inc.

--- a/doc/tstool.8
+++ b/doc/tstool.8
@@ -29,8 +29,18 @@ clock set_to
 clock diff
 .Ar clock1
 .Ar clock2
+.Nm
+interface list
+.Nm
+interface info
+.Ar interface
+.Nm
+interface set_ts
+.Ar interface
+.Ar tx-type
+.Ar rx-filter
 .Sh DESCRIPTION
-Examine and adjust PTP Hardware Clock devices and the system clock.
+Examine and adjust PTP Hardware Clock devices, system clock and interface timestamping settings.
 .Pp
 This utility uses the mechanisms available to sfptpd to manipulate precision clocks on the system.
 .Pp

--- a/doc/tstool.8
+++ b/doc/tstool.8
@@ -6,6 +6,8 @@
 .Nd Timestamping control utility
 .Sh SYNOPSIS
 .Nm
+.Op Fl -help
+.Nm
 clock list
 .Nm
 clock info

--- a/scripts/rpm/el6/sfptpd.spec
+++ b/scripts/rpm/el6/sfptpd.spec
@@ -70,6 +70,7 @@ touch %{buildroot}%{_localstatedir}/lib/%{name}/{config,interfaces,sync-instance
 %files
 %attr(755, root, root) %{_sbindir}/sfptpd
 %attr(755, root, root) %{_sbindir}/sfptpdctl
+%attr(755, root, root) %{_sbindir}/tstool
 %attr(755, root, root) %{_libexecdir}/%{name}/sfptpd_priv_helper
 %attr(755, root, root) %{_sysconfdir}/init.d/sfptpd
 %attr(644, root, root) %config(noreplace) %{_sysconfdir}/sfptpd.conf
@@ -85,6 +86,7 @@ touch %{buildroot}%{_localstatedir}/lib/%{name}/{config,interfaces,sync-instance
 %doc %{_pkgdocdir}/examples/sfptpd_json_parse.html
 %{_mandir}/man8/sfptpd.8*
 %{_mandir}/man8/sfptpdctl.8*
+%{_mandir}/man8/tstool.8*
 %dir %{_localstatedir}/lib/%{name}
 %ghost %{_localstatedir}/lib/%{name}/config
 %ghost %{_localstatedir}/lib/%{name}/interfaces

--- a/scripts/rpm/el7/sfptpd.spec
+++ b/scripts/rpm/el7/sfptpd.spec
@@ -76,6 +76,7 @@ make fast_test
 %files
 %attr(755, root, root) %{_sbindir}/sfptpd
 %attr(755, root, root) %{_sbindir}/sfptpdctl
+%attr(755, root, root) %{_sbindir}/tstool
 %attr(755, root, root) %{_libexecdir}/%{name}/sfptpd_priv_helper
 %attr(644, root, root) %{_unitdir}/sfptpd.service
 %attr(644, root, root) %config(noreplace) %{_sysconfdir}/sfptpd.conf
@@ -89,6 +90,7 @@ make fast_test
 %doc %{_pkgdocdir}/examples/sfptpd_json_parse.html
 %{_mandir}/man8/sfptpd.8*
 %{_mandir}/man8/sfptpdctl.8*
+%{_mandir}/man8/tstool.8*
 %dir %{_localstatedir}/lib/%{name}
 %ghost %{_localstatedir}/lib/%{name}/config
 %ghost %{_localstatedir}/lib/%{name}/interfaces

--- a/scripts/rpm/el8/sfptpd.spec
+++ b/scripts/rpm/el8/sfptpd.spec
@@ -78,6 +78,7 @@ make fast_test
 %files
 %attr(755, root, root) %{_sbindir}/sfptpd
 %attr(755, root, root) %{_sbindir}/sfptpdctl
+%attr(755, root, root) %{_sbindir}/tstool
 %attr(755, root, root) %{_libexecdir}/%{name}/sfptpd_priv_helper
 %attr(644, root, root) %{_unitdir}/sfptpd.service
 %attr(644, root, root) %config(noreplace) %{_sysconfdir}/sfptpd.conf
@@ -91,6 +92,7 @@ make fast_test
 %doc %{_pkgdocdir}/examples/sfptpd_json_parse.html
 %{_mandir}/man8/sfptpd.8*
 %{_mandir}/man8/sfptpdctl.8*
+%{_mandir}/man8/tstool.8*
 %dir %{_localstatedir}/lib/%{name}
 %ghost %{_localstatedir}/lib/%{name}/config
 %ghost %{_localstatedir}/lib/%{name}/interfaces

--- a/scripts/rpm/el9/sfptpd.spec
+++ b/scripts/rpm/el9/sfptpd.spec
@@ -85,6 +85,7 @@ make fast_test
 %files
 %{_sbindir}/sfptpd
 %{_sbindir}/sfptpdctl
+%{_sbindir}/tstool
 %{_libexecdir}/%{name}/sfptpd_priv_helper
 %{_unitdir}/sfptpd.service
 %config(noreplace) %{_sysconfdir}/sfptpd.conf
@@ -99,6 +100,7 @@ make fast_test
 %doc %{_pkgdocdir}/examples/sfptpd_json_parse.html
 %{_mandir}/man8/sfptpd.8*
 %{_mandir}/man8/sfptpdctl.8*
+%{_mandir}/man8/tstool.8*
 %dir %attr(-,sfptpd,sfptpd) %{_localstatedir}/lib/%{name}
 %ghost %attr(-,sfptpd,sfptpd) %{_localstatedir}/lib/%{name}/config
 %ghost %attr(-,sfptpd,sfptpd) %{_localstatedir}/lib/%{name}/interfaces

--- a/src/include/sfptpd_clock.h
+++ b/src/include/sfptpd_clock.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* (c) Copyright 2012-2023 Xilinx, Inc. */
+/* (c) Copyright 2012-2024 Xilinx, Inc. */
 
 #ifndef _SFPTPD_CLOCK_H
 #define _SFPTPD_CLOCK_H
@@ -364,6 +364,16 @@ int sfptpd_clock_adjust_frequency(struct sfptpd_clock *clock, long double freq_a
  * @return 0 for success otherwise an errno status code.
  */
 int sfptpd_clock_get_time(const struct sfptpd_clock *clock, struct sfptpd_timespec *time);
+
+/** Get the clock frequency
+ * @param clock     Pointer to clock instance
+ * @param freq_adj  Pointer to where frequency adjustment in ppb will be written
+ * @param tick      Pointer to where tick lenth in ns will be written
+ * @return 0 for success otherwise an errno status code.
+ */
+int sfptpd_clock_get_frequency(struct sfptpd_clock *clock,
+			       sfptpd_time_t *freq_adj,
+			       sfptpd_time_t *tick_len);
 
 /** Schedule or deschedule a leap second for midnight today UTC for all
  * clocks that support leap second scheduling

--- a/src/include/sfptpd_clock.h
+++ b/src/include/sfptpd_clock.h
@@ -527,5 +527,9 @@ bool sfptpd_clock_is_system(const struct sfptpd_clock *clock);
  */
 bool sfptpd_clock_is_active(const struct sfptpd_clock *clock);
 
+/** Deduplicate phc devices sharing underlying clock
+ * @return 0 on success else error code
+ */
+int sfptpd_clock_deduplicate(void);
 
 #endif /* _SFPTPD_CLOCK_H */

--- a/src/include/sfptpd_general_config.h
+++ b/src/include/sfptpd_general_config.h
@@ -38,6 +38,7 @@
 #define SFPTPD_DEFAULT_DISCIPLINE_ALL_CLOCKS       (true)
 #define SFPTPD_DEFAULT_NON_SFC_NICS                (false)
 #define SFPTPD_DEFAULT_ASSUME_ONE_PHC_PER_NIC      (false)
+#define SFPTPD_DEFAULT_PHC_DEDUP                   (false)
 #define SFPTPD_DEFAULT_TEST_MODE                   (false)
 #define SFPTPD_DEFAULT_RTC_ADJUST                  (true)
 #define SFPTPD_DEFAULT_SELECTION_HOLDOFF_INTERVAL  10
@@ -214,6 +215,7 @@ typedef struct sfptpd_config_general {
 	sfptpd_config_clocks_t clocks;
 	bool non_sfc_nics;
 	bool assume_one_phc_per_nic;
+	bool phc_dedup;
 	bool avoid_efx;
 	bool test_mode;
 	bool daemon;

--- a/src/include/sfptpd_general_config.h
+++ b/src/include/sfptpd_general_config.h
@@ -134,6 +134,7 @@ typedef struct sfptpd_config_clocks {
 	int sync_interval;
 	enum sfptpd_clock_ctrl control;
 	bool persistent_correction;
+	bool no_initial_correction;
 	bool discipline_all;
 	unsigned int num_clocks;
 	char clocks[SFPTPD_CONFIG_TOKENS_MAX][SFPTPD_CONFIG_MAC_STRING_MAX];

--- a/src/include/sfptpd_interface.h
+++ b/src/include/sfptpd_interface.h
@@ -154,6 +154,13 @@ sfptpd_interface_class_t sfptpd_interface_get_class(struct sfptpd_interface *int
  */
 sfptpd_interface_ts_caps_t sfptpd_interface_ptp_caps(struct sfptpd_interface *interface);
 
+/** Gets ethtool ts_info structure for interface
+ * @param interface Pointer to interface instance
+ * @return Timestamp information structure
+ */
+void sfptpd_interface_get_ts_info(const struct sfptpd_interface *interface,
+				  struct ethtool_ts_info *ts_info);
+
 /** Checks if the interface has hardware PTP support
  * @param interface Pointer to interface instance
  * @return Boolean indicating whether PTP is supported

--- a/src/include/sfptpd_interface.h
+++ b/src/include/sfptpd_interface.h
@@ -323,4 +323,11 @@ int sfptpd_interface_driver_stats_reset(struct sfptpd_interface *interface);
  */
 void sfptpd_interface_diagnostics(int trace_level);
 
+/** Reassign interface to another one
+ * @param from_phc phc index of interface to change
+ * @param to_phc phc index to use
+ * @return 0 on success, else errno
+ */
+int sfptpd_interface_reassign_to_nic(int from_phc, int to_phc);
+
 #endif /* _SFPTPD_INTERFACE_H */

--- a/src/include/sfptpd_interface.h
+++ b/src/include/sfptpd_interface.h
@@ -330,4 +330,18 @@ void sfptpd_interface_diagnostics(int trace_level);
  */
 int sfptpd_interface_reassign_to_nic(int from_phc, int to_phc);
 
+/** Suspend hardware timestamping, saving old setting
+ * @param q pointer to location to store affected interface list
+ * @param for_phc clock id whose interfaces to suspend
+ * @return 0 on success, else errno
+ */
+int sfptpd_interface_hw_timestamping_suspend(struct sfptpd_db_query_result *q,
+					     int for_phc);
+
+/** Restore suspend hardware timestamping from saved config
+ * @param q pointer to location with affected interface list
+ * @return 0 on success, else errno
+ */
+int sfptpd_interface_hw_timestamping_restore(struct sfptpd_db_query_result *q);
+
 #endif /* _SFPTPD_INTERFACE_H */

--- a/src/include/sfptpd_time.h
+++ b/src/include/sfptpd_time.h
@@ -82,6 +82,17 @@ void sfptpd_time_negate(struct sfptpd_timespec *a, struct sfptpd_timespec *b);
  */
 bool sfptpd_time_is_greater_or_equal(const struct sfptpd_timespec *a, const struct sfptpd_timespec *b);
 
+/** Compare time a and b and return true if a and b differ by no more then
+ * threshold.
+ * @param a  First time
+ * @param b  Second time
+ * @param c  Equivalence threshold
+ * @return Boolean indicating whether a and b are the same within threshold
+ */
+bool sfptpd_time_equal_within(const struct sfptpd_timespec *a,
+			      const struct sfptpd_timespec *b,
+			      const struct sfptpd_timespec *threshold);
+
 /** Convert a floating point number of seconds into a timespec structure.
  * @param s  Time to convert in seconds
  * @return Time converted to a timespec structure

--- a/src/module.mk
+++ b/src/module.mk
@@ -49,6 +49,9 @@ EXEC_SRCS_$(d) := sfptpd_main.c
 
 EXEC_$(d) := sfptpd
 
+dir := $(d)/tstool
+include $(dir)/module.mk
+
 include mk/executable.mk
 
 include mk/popd.mk

--- a/src/sfptpd_clock.c
+++ b/src/sfptpd_clock.c
@@ -543,7 +543,8 @@ static void fixup_clock(struct sfptpd_clock *clock, struct sfptpd_config_general
         /* Now that we have configured the clock's readonly flag, we can finally load saved frequency corrections
            and epoch startup correction.
         */
-        sfptpd_clock_correct_new(clock);
+	if (!cfg->clocks.no_initial_correction)
+	        sfptpd_clock_correct_new(clock);
 
         return;
 }
@@ -645,7 +646,8 @@ static int new_system_clock(struct sfptpd_config_general *config,
 	sfptpd_clock_system = new;
 
 	configure_new_clock(new, config);
-	sfptpd_clock_correct_new(new);
+	if (!config->clocks.no_initial_correction)
+		sfptpd_clock_correct_new(new);
 
 	*clock = new;
 	return 0;
@@ -1065,7 +1067,8 @@ static void sfptpd_clock_init_interface(int nic_id,
 		} else if (clock->deleted) {
 			/* If a previously-removed NIC is re-inserted we
 			   may need to step the clock */
-			sfptpd_clock_correct_new(clock);
+			if (!general_config->clocks.no_initial_correction)
+				sfptpd_clock_correct_new(clock);
 		}
 
 		/* Link the existing or newly created clock to the interface */

--- a/src/sfptpd_clock.c
+++ b/src/sfptpd_clock.c
@@ -301,7 +301,7 @@ static struct sfptpd_interpolation clock_format_specifiers[] = {
 
 static inline void clock_lock(void)
 {
-	int rc = pthread_mutex_lock(sfptpd_clock_lock);
+	int rc = sfptpd_clock_lock == NULL ? 0 : pthread_mutex_lock(sfptpd_clock_lock);
 	if (rc != 0) {
 		CRITICAL("clock: could not acquire hardware state lock\n");
 		exit(1);
@@ -311,7 +311,7 @@ static inline void clock_lock(void)
 
 static inline void clock_unlock(void)
 {
-	int rc = pthread_mutex_unlock(sfptpd_clock_lock);
+	int rc = sfptpd_clock_lock == NULL ? 0 : pthread_mutex_unlock(sfptpd_clock_lock);
 	if (rc != 0) {
 		CRITICAL("clock: could not release hardware state lock\n");
 		exit(1);

--- a/src/sfptpd_engine.c
+++ b/src/sfptpd_engine.c
@@ -2349,6 +2349,11 @@ static int engine_on_startup(void *context)
 
 	config = engine->config;
 
+	/* Deduplicate non-sfc clock devices */
+	if (engine->general_config->phc_dedup) {
+		sfptpd_clock_deduplicate();
+	}
+
 	engine->clockfeed = sfptpd_clockfeed_create(&engine->clockfeed_thread,
 						    engine->general_config->clocks.sync_interval);
 	if (engine->clockfeed == NULL) {

--- a/src/sfptpd_general_config.c
+++ b/src/sfptpd_general_config.c
@@ -1717,6 +1717,7 @@ static struct sfptpd_config_section *general_config_create(const char *name,
 		new->clocks.persistent_correction = SFPTPD_DEFAULT_PERSISTENT_CLOCK_CORRECTION;
 		new->clocks.discipline_all = SFPTPD_DEFAULT_DISCIPLINE_ALL_CLOCKS;
 		new->clocks.num_clocks = 0;
+		new->clocks.no_initial_correction = false;
 		new->epoch_guard = SFPTPD_DEFAULT_EPOCH_GUARD;
 		new->initial_clock_correction = SFPTPD_DEFAULT_INITIAL_CLOCK_CORRECTION;
 

--- a/src/sfptpd_interface.c
+++ b/src/sfptpd_interface.c
@@ -398,7 +398,7 @@ static struct utsname sysinfo = { .release = "uname-failed" };
  ****************************************************************************/
 
 static inline void interface_lock(void) {
-	int rc = pthread_mutex_lock(sfptpd_interface_lock);
+	int rc = sfptpd_interface_lock == NULL ? 0 : pthread_mutex_lock(sfptpd_interface_lock);
 	if (rc != 0) {
 		CRITICAL("interface: could not acquire hardware state lock\n");
 		exit(1);
@@ -407,7 +407,7 @@ static inline void interface_lock(void) {
 
 
 static inline void interface_unlock(void) {
-	int rc = pthread_mutex_unlock(sfptpd_interface_lock);
+	int rc = sfptpd_interface_lock == NULL ? 0 : pthread_mutex_unlock(sfptpd_interface_lock);
 	if (rc != 0) {
 		CRITICAL("interface: could not release hardware state lock\n");
 		exit(1);

--- a/src/sfptpd_time.c
+++ b/src/sfptpd_time.c
@@ -98,6 +98,19 @@ void sfptpd_time_subtract(struct sfptpd_timespec *c,
 	sfptpd_time_normalise(c);
 }
 
+bool sfptpd_time_equal_within(const struct sfptpd_timespec *a,
+			      const struct sfptpd_timespec *b,
+			      const struct sfptpd_timespec *threshold)
+{
+	struct sfptpd_timespec c;
+
+	sfptpd_time_subtract(&c, a, b);
+	if (c.sec < 0)
+		sfptpd_time_negate(&c, &c);
+
+	return sfptpd_time_is_greater_or_equal(threshold, &c);
+}
+
 int sfptpd_time_cmp(const struct sfptpd_timespec *a, const struct sfptpd_timespec *b)
 {
 	if (a->sec < b->sec)

--- a/src/tstool/module.mk
+++ b/src/tstool/module.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# (c) Copyright 2024 Advanced Micro Devices, Inc.
+
+# sfptpdctl makefile
+
+include mk/pushd.mk
+
+# Include the makefiles for any subdirectories
+
+# Local variables
+
+EXEC_SRCS_$(d) := tstool.c
+
+EXEC_$(d) := tstool
+
+include mk/executable.mk
+
+include mk/popd.mk
+
+# fin

--- a/src/tstool/tstool.c
+++ b/src/tstool/tstool.c
@@ -298,6 +298,8 @@ static int clock_command(int argc, char *argv[])
 	const struct clock_command *cmd;
 	const char *command;
 	size_t num_clocks;
+	sfptpd_time_t freq_adj;
+	sfptpd_time_t tick_len;
 	sfptpd_time_t f;
 	int tokens;
 	int rc = 0;
@@ -344,17 +346,22 @@ static int clock_command(int argc, char *argv[])
 		sfptpd_clock_free_active_snapshot(all_clocks);
 		break;
 	case CLOCK_CMD_INFO:
+		sfptpd_clock_get_frequency(clocks[0], &freq_adj, &tick_len);
 		printf("short-name: %s\n"
 		       "long-name: %s\n"
 		       "hw-id: %s\n"
 		       "persistent-freq-correction: %.3Lf ppb\n"
 		       "max-freq-adj: %.3Lf ppb\n"
+		       "freq-adj: %.3Lf ppb\n"
+		       "tick-len: %.3Lf s\n"
 		       "diff-method: %s\n",
 		       sfptpd_clock_get_short_name(clocks[0]),
 		       sfptpd_clock_get_long_name(clocks[0]),
 		       sfptpd_clock_get_hw_id_string(clocks[0]),
 		       sfptpd_clock_get_freq_correction(clocks[0]),
 		       sfptpd_clock_get_max_frequency_adjustment(clocks[0]),
+		       freq_adj,
+		       tick_len / 1000000000.0L,
 		       sfptpd_clock_get_diff_method(clocks[0]));
 		break;
 	case CLOCK_CMD_GET:

--- a/src/tstool/tstool.c
+++ b/src/tstool/tstool.c
@@ -33,12 +33,14 @@
  ****************************************************************************/
 
 #define OPT_PERSISTENT 0x10000
+#define OPT_INITIAL 0x10001
 
 static const char *opts_short = "hv";
 static const struct option opts_long[] = {
 	{ "help", 0, NULL, (int) 'h' },
 	{ "verbose", 0, NULL, (int) 'v' },
 	{ "persistent", 0, NULL, OPT_PERSISTENT },
+	{ "initial", 0, NULL, OPT_INITIAL },
 	{ NULL, 0, NULL, 0 }
 };
 
@@ -264,6 +266,7 @@ static void usage(FILE *stream)
 		"\n"
 		"  OPTIONS\n"
 		"        --persistent            Use sfptpd persistent frequency adjustment\n"
+		"        --initial               Perform sfptpd initial clock correction\n"
 		"    -h, --help                  Show usage\n"
 		"    -v, --verbose               Be verbose\n\n"
 		"  CLOCK SUBSYSTEM\n"
@@ -550,6 +553,7 @@ int main(int argc, char *argv[])
 	gconf->non_sfc_nics = true;
 	gconf->timestamping.disable_on_exit = false;
 	gconf->clocks.persistent_correction = false;
+	gconf->clocks.no_initial_correction = true;
 
 	/* Handle command line arguments */
 	while ((opt = getopt_long(argc, argv, opts_short, opts_long, &index)) != -1) {
@@ -564,6 +568,9 @@ int main(int argc, char *argv[])
 			break;
 		case OPT_PERSISTENT:
 			gconf->clocks.persistent_correction = true;
+			break;
+		case OPT_INITIAL:
+			gconf->clocks.no_initial_correction = false;
 			break;
 		default:
 			fprintf(stderr, "unexpected option: %s\n", argv[optind]);

--- a/src/tstool/tstool.c
+++ b/src/tstool/tstool.c
@@ -113,6 +113,7 @@ enum clock_command_e {
 	CLOCK_CMD_SLEW,
 	CLOCK_CMD_SET_TO,
 	CLOCK_CMD_DIFF,
+	CLOCK_CMD_DEDUP,
 	CLOCK_CMD_INVALID
 };
 
@@ -151,6 +152,7 @@ static const struct clock_command clock_cmds[] = {
 	{ CLOCK_CMD_SLEW,    "slew",    1 },
 	{ CLOCK_CMD_SET_TO,  "set_to",  2 },
 	{ CLOCK_CMD_DIFF,    "diff",    2 },
+	{ CLOCK_CMD_DEDUP,   "dedup",   0 },
 	{ CLOCK_CMD_INVALID, "INVALID", 0 },
 };
 
@@ -276,7 +278,8 @@ static void usage(FILE *stream)
 		"    clock step CLOCK OFFSET     Step clock\n"
 		"    clock slew CLOCK PPB        Adjust clock frequency\n"
 		"    clock set_to CLOCK1 CLOCK2  CLOCK1 := CLOCK2\n"
-		"    clock diff CLOCK1 CLOCK2    CLOCK1 - CLOCK2\n\n"
+		"    clock diff CLOCK1 CLOCK2    CLOCK1 - CLOCK2\n"
+		"    clock dedup                 Deduplicate shared phc devices\n\n"
 		"      CLOCK := <phcN> | <ethN> | system\n\n"
 		"  INTERFACE SUBSYSTEM\n"
 		"    interface list              List physical interfaces\n"
@@ -286,7 +289,6 @@ static void usage(FILE *stream)
                 "      See 'info' response for available TX and RX modes\n",
 		program_invocation_short_name);
 }
-
 
 static int clock_command(int argc, char *argv[])
 {
@@ -396,6 +398,9 @@ static int clock_command(int argc, char *argv[])
 		break;
 	case CLOCK_CMD_SET_TO:
 		rc = sfptpd_clock_set_time(clocks[0], clocks[1], NULL, false);
+		break;
+	case CLOCK_CMD_DEDUP:
+		rc = sfptpd_clock_deduplicate();
 		break;
 	default:
 		fprintf(stderr, "unknown clock command: %s\n", command);
@@ -570,7 +575,7 @@ int main(int argc, char *argv[])
 			goto fail;
 		case 'v':
 			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_NETLINK, 3);
-			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_SFPTPD, 3);
+			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_SFPTPD, 6);
 			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_CLOCKS, 3);
 			break;
 		case OPT_PERSISTENT:

--- a/src/tstool/tstool.c
+++ b/src/tstool/tstool.c
@@ -32,10 +32,13 @@
  * Constant
  ****************************************************************************/
 
+#define OPT_PERSISTENT 0x10000
+
 static const char *opts_short = "hv";
 static const struct option opts_long[] = {
 	{ "help", 0, NULL, (int) 'h' },
 	{ "verbose", 0, NULL, (int) 'v' },
+	{ "persistent", 0, NULL, OPT_PERSISTENT },
 	{ NULL, 0, NULL, 0 }
 };
 
@@ -208,18 +211,7 @@ static int decode_option(const char **names, size_t num_known,
 
 static int do_init(void)
 {
-        struct sfptpd_config_general *gconf;
 	int rc;
-
-	/* Initialise config */
-	rc = sfptpd_config_create(&config);
-	if (rc != 0)
-		return EXIT_FAILURE;
-
-	/* Tweak config */
-	gconf = sfptpd_general_config_get(config);
-	gconf->non_sfc_nics = true;
-	gconf->timestamping.disable_on_exit = false;
 
 	/* Start netlink service */
 	netlink = sfptpd_netlink_init();
@@ -263,7 +255,6 @@ static void do_finit(void)
 	sfptpd_interface_shutdown(config);
 	if (netlink != NULL)
 		sfptpd_netlink_finish(netlink);
-	sfptpd_config_destroy(config);
 }
 
 static void usage(FILE *stream)
@@ -272,6 +263,7 @@ static void usage(FILE *stream)
 		"syntax: %s [OPTIONS] SUBSYSTEM COMMAND..\n"
 		"\n"
 		"  OPTIONS\n"
+		"        --persistent            Use sfptpd persistent frequency adjustment\n"
 		"    -h, --help                  Show usage\n"
 		"    -v, --verbose               Be verbose\n\n"
 		"  CLOCK SUBSYSTEM\n"
@@ -342,7 +334,6 @@ static int clock_command(int argc, char *argv[])
 
 	switch(cmd->tag) {
 	case CLOCK_CMD_LIST:
-		sfptpd_clock_diagnostics(3);
 		all_clocks = sfptpd_clock_get_active_snapshot(&num_clocks);
 		for (i = 0; i < num_clocks; i++) {
 			printf("%s\n", sfptpd_clock_get_long_name(all_clocks[i]));
@@ -465,7 +456,6 @@ static int intf_command(int argc, char *argv[])
 
 	switch(cmd->tag) {
 	case INTF_CMD_LIST:
-		sfptpd_interface_diagnostics(3);
 		query_result = sfptpd_interface_get_active_ptp_snapshot();
 		for (i = 0; i < query_result.num_records; i++) {
 			struct sfptpd_interface **intfp = query_result.record_ptrs[i];
@@ -543,13 +533,23 @@ static int intf_command(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
+	struct sfptpd_config_general *gconf;
 	const char *subsystem;
 	int index;
 	int opt;
 	int rc = EXIT_FAILURE;
+	int ret;
 
-	if (do_init() != 0)
-		goto fail;
+	/* Initialise config */
+	ret = sfptpd_config_create(&config);
+	if (ret != 0)
+		return EXIT_FAILURE;
+
+	/* Tweak config */
+	gconf = sfptpd_general_config_get(config);
+	gconf->non_sfc_nics = true;
+	gconf->timestamping.disable_on_exit = false;
+	gconf->clocks.persistent_correction = false;
 
 	/* Handle command line arguments */
 	while ((opt = getopt_long(argc, argv, opts_short, opts_long, &index)) != -1) {
@@ -561,6 +561,9 @@ int main(int argc, char *argv[])
 			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_NETLINK, 3);
 			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_SFPTPD, 3);
 			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_CLOCKS, 3);
+			break;
+		case OPT_PERSISTENT:
+			gconf->clocks.persistent_correction = true;
 			break;
 		default:
 			fprintf(stderr, "unexpected option: %s\n", argv[optind]);
@@ -574,6 +577,9 @@ int main(int argc, char *argv[])
 		goto fail;
 	}
 
+	if (do_init() != 0)
+		goto fail;
+
 	subsystem = argv[optind++];
 
 	if (!strcmp(subsystem, "clock")) {
@@ -586,8 +592,10 @@ int main(int argc, char *argv[])
 		usage(stderr);
 	}
 
-fail:
 	do_finit();
+
+fail:
+	sfptpd_config_destroy(config);
 
 	return rc;
 }

--- a/src/tstool/tstool.c
+++ b/src/tstool/tstool.c
@@ -1,0 +1,335 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* (c) Copyright 2024 Advanced Micro Devices, Inc. */
+
+/* Timestamping control utility */
+
+#include <assert.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <regex.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <fcntl.h>
+
+#include "sfptpd_config.h"
+#include "sfptpd_general_config.h"
+#include "sfptpd_netlink.h"
+#include "sfptpd_clock.h"
+#include "sfptpd_interface.h"
+#include "sfptpd_logging.h"
+
+
+/****************************************************************************
+ * Constant
+ ****************************************************************************/
+
+static const char *opts_short = "hv";
+static const struct option opts_long[] = {
+	{ "help", 0, NULL, (int) 'h' },
+	{ "verbose", 0, NULL, (int) 'v' },
+	{ NULL, 0, NULL, 0 }
+};
+
+
+/****************************************************************************
+ * Types
+ ****************************************************************************/
+
+enum clock_command_e {
+	CLOCK_CMD_LIST,
+	CLOCK_CMD_INFO,
+	CLOCK_CMD_GET,
+	CLOCK_CMD_STEP,
+	CLOCK_CMD_SLEW,
+	CLOCK_CMD_SET_TO,
+	CLOCK_CMD_DIFF,
+	CLOCK_CMD_INVALID
+};
+
+struct clock_command {
+	enum clock_command_e tag;
+	const char *name;
+	int clock_args;
+};
+
+
+/****************************************************************************
+ * Local Data
+ ****************************************************************************/
+
+static struct sfptpd_config *config = NULL;
+static struct sfptpd_nl_state *netlink = NULL;
+static const struct sfptpd_link_table *initial_link_table = NULL;
+
+static const struct clock_command clock_cmds[] = {
+	{ CLOCK_CMD_LIST,    "list",    0 },
+	{ CLOCK_CMD_INFO,    "info",    1 },
+	{ CLOCK_CMD_GET,     "get",     1 },
+	{ CLOCK_CMD_STEP,    "step",    1 },
+	{ CLOCK_CMD_SLEW,    "slew",    1 },
+	{ CLOCK_CMD_SET_TO,  "set_to",  2 },
+	{ CLOCK_CMD_DIFF,    "diff",    2 },
+	{ CLOCK_CMD_INVALID, "INVALID", 0 },
+};
+
+
+/****************************************************************************
+ * Local functions
+ ****************************************************************************/
+
+static int do_init(void)
+{
+        struct sfptpd_config_general *gconf;
+	int rc;
+
+	/* Initialise config */
+	rc = sfptpd_config_create(&config);
+	if (rc != 0)
+		return EXIT_FAILURE;
+
+	/* Tweak config */
+	gconf = sfptpd_general_config_get(config);
+	gconf->non_sfc_nics = true;
+
+	/* Start netlink service */
+	netlink = sfptpd_netlink_init();
+	if (netlink == NULL) {
+		CRITICAL("could not start netlink\n");
+		return EXIT_FAILURE;
+	}
+
+	rc = sfptpd_netlink_scan(netlink);
+	if (rc != 0) {
+		CRITICAL("scanning with netlink, %s\n",
+			 strerror(rc));
+		return rc;
+	}
+
+	/* Wait 5 seconds for initial link table */
+	initial_link_table = sfptpd_netlink_table_wait(netlink, 1, 5000);
+	if (initial_link_table == NULL) {
+		CRITICAL("could not get initial link table, %s\n",
+			 strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	/* Start clock management */
+	rc = sfptpd_clock_initialise(config, NULL);
+	if (rc != 0)
+		return EXIT_FAILURE;
+
+	/* Start interface management */
+	rc = sfptpd_interface_initialise(config, NULL,
+					 initial_link_table);
+	if (rc != 0)
+		return EXIT_FAILURE;
+
+	return 0;
+}
+
+static void do_finit(void)
+{
+	sfptpd_clock_shutdown();
+	sfptpd_interface_shutdown(config);
+	if (netlink != NULL)
+		sfptpd_netlink_finish(netlink);
+	sfptpd_config_destroy(config);
+}
+
+static void usage(FILE *stream)
+{
+	fprintf(stream,
+		"syntax: %s [OPTIONS] SUBSYSTEM COMMAND..\n"
+		"\n"
+		"  OPTIONS\n"
+		"    -h, --help                  Show usage\n"
+		"    -v, --verbose               Be verbose\n\n"
+		"  CLOCK SUBSYSTEM\n"
+		"    clock list                  List clocks\n"
+		"    clock info                  Show clock information\n"
+		"    clock get CLOCK             Read clock\n"
+		"    clock step CLOCK OFFSET     Step clock\n"
+		"    clock slew CLOCK PPB        Adjust clock frequency\n"
+		"    clock set_to CLOCK1 CLOCK2  CLOCK1 := CLOCK2\n"
+		"    clock diff CLOCK1 CLOCK2    CLOCK1 - CLOCK2\n\n"
+		"      CLOCK := <phcN> | <ethN> | system\n",
+		program_invocation_short_name);
+}
+
+
+static int clock_command(int argc, char *argv[])
+{
+#define MAX_CLOCKS 2
+	struct sfptpd_timespec times[MAX_CLOCKS];
+	struct sfptpd_clock *clocks[MAX_CLOCKS];
+	struct sfptpd_interface *interface;
+	struct sfptpd_clock **all_clocks;
+	const struct clock_command *cmd;
+	const char *command;
+	size_t num_clocks;
+	sfptpd_time_t f;
+	int tokens;
+	int rc = 0;
+	int i;
+
+	if (argc < 1) {
+		usage(stderr);
+		return EXIT_FAILURE;
+	}
+
+	command = argv[0];
+
+	for (cmd = clock_cmds;
+	     cmd->tag != CLOCK_CMD_INVALID &&
+	     strcmp(command, cmd->name);
+	     cmd++);
+
+	assert(cmd->clock_args <= MAX_CLOCKS);
+	if (argc - 1 < cmd->clock_args) {
+		ERROR("insufficient number of clocks specified\n");
+		usage(stderr);
+		return EXIT_FAILURE;
+	}
+
+	for (i = 0; i < cmd->clock_args; i++) {
+		const char *clock_ref = argv[1 + i];
+		clocks[i] = sfptpd_clock_find_by_name(clock_ref);
+		if (clocks[i] == NULL &&
+		    (interface = sfptpd_interface_find_by_name(clock_ref))) {
+			clocks[i] = sfptpd_interface_get_clock(interface);
+		}
+		if (clocks[i] == NULL) {
+			fprintf(stderr, "unknown clock: %s\n", clock_ref);
+			return EXIT_FAILURE;
+		}
+	}
+
+	switch(cmd->tag) {
+	case CLOCK_CMD_LIST:
+		sfptpd_clock_diagnostics(3);
+		all_clocks = sfptpd_clock_get_active_snapshot(&num_clocks);
+		for (i = 0; i < num_clocks; i++) {
+			printf("%s\n", sfptpd_clock_get_long_name(all_clocks[i]));
+		}
+		sfptpd_clock_free_active_snapshot(all_clocks);
+		break;
+	case CLOCK_CMD_INFO:
+		printf("short-name: %s\n"
+		       "long-name: %s\n"
+		       "hw-id: %s\n"
+		       "persistent-freq-correction: %.3Lf ppb\n"
+		       "max-freq-adj: %.3Lf ppb\n"
+		       "diff-method: %s\n",
+		       sfptpd_clock_get_short_name(clocks[0]),
+		       sfptpd_clock_get_long_name(clocks[0]),
+		       sfptpd_clock_get_hw_id_string(clocks[0]),
+		       sfptpd_clock_get_freq_correction(clocks[0]),
+		       sfptpd_clock_get_max_frequency_adjustment(clocks[0]),
+		       sfptpd_clock_get_diff_method(clocks[0]));
+		break;
+	case CLOCK_CMD_GET:
+		rc = sfptpd_clock_get_time(clocks[0], times + 0);
+		printf("%s: " SFPTPD_FMT_SFTIMESPEC "\n",
+		       sfptpd_clock_get_short_name(clocks[0]),
+		       SFPTPD_ARGS_SFTIMESPEC(times[0]));
+		break;
+	case CLOCK_CMD_STEP:
+		tokens = sscanf(argv[1 + cmd->clock_args], "%Lf", &f);
+		if (tokens != 1) {
+			ERROR("invalid offset specified\n");
+			return EXIT_FAILURE;
+		}
+		sfptpd_time_float_s_to_timespec(f, times + 0);
+		rc = sfptpd_clock_adjust_time(clocks[0], times + 0);
+		break;
+	case CLOCK_CMD_SLEW:
+		tokens = sscanf(argv[1 + cmd->clock_args], "%Lf", &f);
+		if (tokens != 1) {
+			ERROR("invalid frequency adjustment specified\n");
+			return EXIT_FAILURE;
+		}
+		rc = sfptpd_clock_adjust_frequency(clocks[0], f);
+		break;
+	case CLOCK_CMD_DIFF:
+		rc = sfptpd_clock_compare(clocks[0], clocks[1], times + 0);
+		printf("%s-%s: " SFPTPD_FMT_SSFTIMESPEC "\n",
+		       sfptpd_clock_get_short_name(clocks[0]),
+		       sfptpd_clock_get_short_name(clocks[1]),
+		       SFPTPD_ARGS_SSFTIMESPEC(times[0]));
+		break;
+	case CLOCK_CMD_SET_TO:
+		rc = sfptpd_clock_set_time(clocks[0], clocks[1], NULL, false);
+		break;
+	default:
+		fprintf(stderr, "unknown clock command: %s\n", command);
+		usage(stderr);
+		return EXIT_FAILURE;
+	}
+
+	if (rc != 0) {
+		ERROR("tstool: clock: %s: %s\n", command, strerror(rc));
+		return EXIT_FAILURE;
+	}
+
+	return EXIT_SUCCESS;
+}
+
+
+/****************************************************************************
+ * Global functions
+ ****************************************************************************/
+
+int main(int argc, char *argv[])
+{
+	const char *subsystem;
+	int index;
+	int opt;
+	int rc = EXIT_FAILURE;
+
+	if (do_init() != 0)
+		goto fail;
+
+	/* Handle command line arguments */
+	while ((opt = getopt_long(argc, argv, opts_short, opts_long, &index)) != -1) {
+		switch (opt) {
+		case 'h':
+			usage(stdout);
+			goto fail;
+		case 'v':
+			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_NETLINK, 3);
+			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_SFPTPD, 3);
+			sfptpd_log_set_trace_level(SFPTPD_COMPONENT_ID_CLOCKS, 3);
+			break;
+		default:
+			fprintf(stderr, "unexpected option: %s\n", argv[optind]);
+			usage(stderr);
+			goto fail;
+		}
+	}
+
+	if (argc - optind < 1) {
+		usage(stderr);
+		goto fail;
+	}
+
+	subsystem = argv[optind++];
+
+	if (!strcmp(subsystem, "clock")) {
+		rc = clock_command(argc - optind, argv + optind);
+	} else {
+		fprintf(stderr, "unknown subsystem: %s\n", subsystem);
+		usage(stderr);
+	}
+
+fail:
+	do_finit();
+
+	return rc;
+}


### PR DESCRIPTION
Drivers for non-Solarflare NICs which present multiple PHC devices for the same underlying clock break sfptpd's monolithic model of managing clock sync between all the NICs on the system as well as any remote sync involved because sfptpd cannot discover the true underlying relationship between the PHC devices and their underlying clocks.

This patch series adds an option `phc_dedup on` which can be used in the `[general]` configuration section to perform a destructive calibration exercise at startup to determine mappings between PHC devices and underlying clocks in order to choose which devices sfptpd should use for syncing.

A new tool, `tstool`, is also added which can help with testing this feature along with other useful control and status operations. This means that similar tools supplied with other PTP daemons do not need to be installed when sfptpd is installed, simply to script some system administration housekeeping exercises.

Here are some useful command examples:

```
tstool clock list
tstool clock info phc1
tstool clock get phc1
tstool clock step phc1 1.000
tstool clock set_to phc1 system
tstool clock diff phc1 phc2
tstool clock dedup
tstool interface list
tstool interface info enp4s0f0
tstool interface set_ts on all
```

```
$ sudo build/tstool clock diff eno8303 ens1f0
2024-10-11 15:40:12.666234: info: phc0: using diff method SYS_OFFSET_EXTENDED
2024-10-11 15:40:12.666734: info: phc1: using diff method SYS_OFFSET_EXTENDED
2024-10-11 15:40:12.668510: info: phc2: using diff method SYS_OFFSET_PRECISE
phc0-phc2: -0.508612751000
$ sudo build/tstool clock step eno8303 0.5
2024-10-11 15:40:34.953420: info: phc0: using diff method SYS_OFFSET_EXTENDED
2024-10-11 15:40:34.954127: info: phc1: using diff method SYS_OFFSET_EXTENDED
2024-10-11 15:40:34.955823: info: phc2: using diff method SYS_OFFSET_PRECISE
2024-10-11 15:40:34.957185: info: clock phc0: applying offset 0.500000000 seconds
$ sudo build/tstool clock diff eno8303 ens1f0
2024-10-11 15:40:37.407696: info: phc0: using diff method SYS_OFFSET_EXTENDED
2024-10-11 15:40:37.408176: info: phc1: using diff method SYS_OFFSET_EXTENDED
2024-10-11 15:40:37.409940: info: phc2: using diff method SYS_OFFSET_PRECISE
phc0-phc2: -0.008619378000
```

And an example of the deduplication process:

```
$ sudo build/tstool clock dedup
2024-07-15 10:55:49.803383: info: phc0: using diff method SYS_OFFSET_EXTENDED
2024-07-15 10:55:49.804448: info: phc1: using diff method SYS_OFFSET_EXTENDED
2024-07-15 10:55:49.805479: info: phc2: using diff method SYS_OFFSET_EXTENDED
2024-07-15 10:55:49.806482: info: phc4: using diff method SYS_OFFSET_EXTENDED
2024-07-15 10:55:49.809066: info: phc3: using diff method SYS_OFFSET_PRECISE
2024-07-15 10:55:49.811074: notice: clock: identifying duplicate phc clocks, a destructive operation
2024-07-15 10:55:49.811122: info: interface eno1: suspended hardware timestamping
2024-07-15 10:55:49.811180: info: interface eno2: suspended hardware timestamping
2024-07-15 10:55:49.811254: info: interface eno3: suspended hardware timestamping
2024-07-15 10:55:49.811332: info: interface eno4: suspended hardware timestamping
2024-07-15 10:55:49.811394: info: clock phc0: applying offset -1.000000000 seconds
2024-07-15 10:55:50.811652: info: clock phc0: deduplication: phc0 governs phc1
2024-07-15 10:55:50.811728: info: clock phc0: deduplication: phc0 governs phc2
2024-07-15 10:55:50.811789: info: clock phc0: deduplication: phc0 governs phc4
2024-07-15 10:55:50.811799: info: clock phc0: applying offset 1.000000000 seconds
2024-07-15 10:55:51.811934: info: clock phc1: applying offset -1.000000000 seconds
2024-07-15 10:55:52.812167: info: clock phc1: deduplication: did not take test adjustment
2024-07-15 10:55:52.812307: info: clock phc1: applying offset 1.000000000 seconds
2024-07-15 10:55:53.812467: info: clock phc2: applying offset -1.000000000 seconds
2024-07-15 10:55:54.812700: info: clock phc2: deduplication: did not take test adjustment
2024-07-15 10:55:54.812843: info: clock phc2: applying offset 1.000000000 seconds
2024-07-15 10:55:55.812996: info: clock phc4: applying offset -1.000000000 seconds
2024-07-15 10:55:56.813225: info: clock phc4: deduplication: did not take test adjustment
2024-07-15 10:55:56.813366: info: clock phc4: applying offset 1.000000000 seconds
2024-07-15 10:55:57.813498: notice: clock: identification of duplicate phc clocks complete
2024-07-15 10:55:57.813538: info: interface eno1: restored hardware timestamping setting
2024-07-15 10:55:57.813553: info: interface eno2: restored hardware timestamping setting
2024-07-15 10:55:57.813569: info: interface: reassigned eno2 to nic id 0
2024-07-15 10:55:57.813585: info: interface eno3: restored hardware timestamping setting
2024-07-15 10:55:57.813597: info: interface: reassigned eno3 to nic id 0
2024-07-15 10:55:57.813617: info: interface eno4: restored hardware timestamping setting
2024-07-15 10:55:57.813628: info: interface: reassigned eno4 to nic id 0
```