### PR TITLE
phc: record step on live clocks only. (Fixes Xilinx-CNS/sfptpd#17)

### DIFF
--- a/src/sfptpd_clock.c
+++ b/src/sfptpd_clock.c
@@ -1095,7 +1095,8 @@ static void clock_record_step(void)
 	clock_lock();
 	for (clock = sfptpd_clock_list_head; clock != NULL; clock = clock->next) {
 		assert(clock->magic == SFPTPD_CLOCK_MAGIC);
-		if (clock->type != SFPTPD_CLOCK_TYPE_SYSTEM)
+		if (clock->type != SFPTPD_CLOCK_TYPE_SYSTEM &&
+		    clock->u.nic.phc != NULL)
 			sfptpd_phc_record_step(clock->u.nic.phc);
 	}
 	clock_unlock();


### PR DESCRIPTION
Hi @sasharozenson, does this fix your issue? (Fixes #17)?

It is expected that some clock objects within sfptpd at times refer to devices that are not currently available (since they may come back and we want to treat them as the same entity when they do) - this function to record that a step has happened in any clock (to avoid stale clock comparison data bring used) should legitimately be happy to skip over clocks that don't currently physically exist.