### PR TITLE
SWPTP-1598 - Frequency adjustment feedback into Peirce filter.

### DIFF
--- a/src/ptp/ptpd2/dep/servo.c
+++ b/src/ptp/ptpd2/dep/servo.c
@@ -359,7 +359,12 @@ static bool servo_update(ptp_servo_t *servo)
 
 	offset = sfptpd_ptp_tsd_get_offset_from_master(filtered_delay);
 
-	outlier = sfptpd_peirce_filter_update(servo->peirce_filt, offset);
+	/* Get monotonic timestamp for the Peirce filter */
+	struct sfptpd_timespec timestamp = sfptpd_ptp_tsd_get_monotonic_time(&servo->timestamps);
+
+	outlier = sfptpd_peirce_filter_update(servo->peirce_filt, offset,
+					      servo->frequency_adjustment - servo->frequency_correction,
+					      &timestamp);
 	servo->counters.outliers_num_samples += 1;
 	if (outlier) {
 		/* We have an outlier so don't update the offset from master or

--- a/test/sfptpd_test_filters.c
+++ b/test/sfptpd_test_filters.c
@@ -218,11 +218,15 @@ static int test_outlier_filter(void)
 	long double data[MAX_PEIRCE_SAMPLES];
 	unsigned int num_samples, i, j, s, total, outliers;
 	struct sfptpd_stats_std_dev stat;
+	struct sfptpd_timespec timestamp;
 	struct sfptpd_peirce_filter *filter;
 	int r;
 
 	outliers = 0;
 	total = 0;
+
+	/* Initialize timestamp for testing */
+	sfclock_gettime(CLOCK_MONOTONIC, &timestamp);
 
 	/* NUM_PEIRCE_ITERATIONS Iterations */
 	for (i = 0; i < NUM_PEIRCE_ITERATIONS; i++) {
@@ -245,7 +249,11 @@ static int test_outlier_filter(void)
 		for (s = 0; s < num_samples; s++) {
 			data[s] = appox_normal();
 
-			r = sfptpd_peirce_filter_update(filter, data[s]);
+			/* Simulate time progression */
+			timestamp.nsec += 1000000; /* Add 1ms */
+			if (timestamp.nsec >= 1000000000) { timestamp.sec++; timestamp.nsec -= 1000000000; }
+
+			r = sfptpd_peirce_filter_update(filter, data[s], 0.0, &timestamp);
 			if (r != 0)
 				outliers++;
 
@@ -258,7 +266,11 @@ static int test_outlier_filter(void)
 				data[s] = appox_normal();
 				sfptpd_stats_std_dev_add_sample(&stat, data[s]);
 
-				r = sfptpd_peirce_filter_update(filter, data[s]);
+				/* Simulate time progression */
+				timestamp.nsec += 1000000; /* Add 1ms */
+				if (timestamp.nsec >= 1000000000) { timestamp.sec++; timestamp.nsec -= 1000000000; }
+
+				r = sfptpd_peirce_filter_update(filter, data[s], 0.0, &timestamp);
 				if (r != 0)
 					outliers ++;
 			}


### PR DESCRIPTION
The Peirce filter does not take the current frequency adjustment rate into account. When configured with lower outlier adaptation factors (e.g. 0.3), sfptpd has difficulty synchronizing to the GM if a pre-existing time drift is present at startup. This commit introduces a feedback loop from the frequency adjustment PID filter into the Peirce outlier filter, allowing the non-outlier criterion window to adjust dynamically.