### PR TITLE
Fix warnings turned into errors

### DIFF
--- a/src/include/sfptpd_config.h
+++ b/src/include/sfptpd_config.h
@@ -462,7 +462,7 @@
 
 /** Produce help text for default string config quoted macro values */
 #define SFPTPD_CONFIG_DFL_STR(val) _Generic((val), \
-	char *: "Defaults to " val)
+	const char *: "Defaults to " val, char *: "Defaults to " val)
 
 /** Enumeration of different config section categories. */
 enum sfptpd_config_category {

--- a/src/sfptpd_clock.c
+++ b/src/sfptpd_clock.c
@@ -1174,7 +1174,7 @@ static void sfptpd_clock_init_interface(int nic_id,
 		/* Link the existing or newly created clock to the interface */
 		sfptpd_interface_set_clock(interface, clock);
 
-		if (is_new) {
+		if (is_new && clock) {
 			/* Set disciplining state for new clock */
 			rc = configure_new_clock(clock, general_config);
 			if (rc != 0) {


### PR DESCRIPTION
and improve const correctness a little bit.

A common theme is that the warning set varies depending on exact gcc version and optimization settings (e.g. `-Og` vs. `-O2` vs. `-O3`).