### PR TITLE
ON-17533: Do not enable scl gcc-11 on unit machines

### DIFF
--- a/ci/test.groovy
+++ b/ci/test.groovy
@@ -16,7 +16,7 @@ nm.slack_notify() {
     }
 
     stage('build') {
-      sh('scl enable gcc-toolset-11 make')
+      sh('make')
     }
 
     stage('check') {


### PR DESCRIPTION
rhel9 unit machines have gcc-11 implicitly and the scl command doesn't work on them. This is the simplest solution to fixing the sfptpd pipeline.

Testing done:
ran make and make test all works

old mechanism ran into:
xcb-jenkins-onload@xcb-onload-unit-1$ scl enable gcc-toolset-11 make
Unable to get file status /etc/scl/conf/gcc-toolset-11: No such file or directory